### PR TITLE
Fix 500 error when NULL is sent

### DIFF
--- a/src/Utilities/UrlQuery.php
+++ b/src/Utilities/UrlQuery.php
@@ -297,7 +297,11 @@ class UrlQuery
 
         foreach ($params as $key => $value)
         {
-            if (is_bool($value))
+            if (is_null($value))
+            {
+                continue;
+            }
+            else if (is_bool($value))
             {
                 $value = StringUtilities::booleanLiteral($value);
             }


### PR DESCRIPTION
After 7250437947a0181ee51a856b7758ef4face06df3, the `PulseBoard::createPulse` function would result in a 500 response with the default NULL parameters. This was because it was attempting to send a NULL for the `update` value.