### PR TITLE
Pagination options in getPulses method - resolves #16

### DIFF
--- a/src/PulseBoard.php
+++ b/src/PulseBoard.php
@@ -369,17 +369,18 @@ class PulseBoard extends SubscribableObject
      *
      * @since  0.1.0
      *
-     * @param int $perPage
-     * @param int $page
+     * @param int $perPage  default: 15, max: 25
+     * @param int $page     default: 1
      * @return Pulse[]
      */
-    public function getPulses ($perPage = 25, $page = 1)
+    public function getPulses ($perPage = null, $page = null)
     {
         $url    = sprintf("%s/%d/pulses.json", self::apiEndpoint(), $this->getId());
-        $params = [
-            'per_page' => $perPage,
-            'page'     => $page,
-        ];
+        $params = [];
+        
+        self::setIfNotNullOrEmpty($params, 'per_page', $perPage);
+        self::setIfNotNullOrEmpty($params, 'page', $page);
+
         $data   = self::sendGet($url, $params);
         $pulses = [];
 

--- a/src/PulseBoard.php
+++ b/src/PulseBoard.php
@@ -369,12 +369,18 @@ class PulseBoard extends SubscribableObject
      *
      * @since  0.1.0
      *
+     * @param int $perPage
+     * @param int $page
      * @return Pulse[]
      */
-    public function getPulses ()
+    public function getPulses ($perPage = 25, $page = 1)
     {
         $url    = sprintf("%s/%d/pulses.json", self::apiEndpoint(), $this->getId());
-        $data   = self::sendGet($url);
+        $params = [
+            'per_page' => $perPage,
+            'page'     => $page,
+        ];
+        $data   = self::sendGet($url, $params);
         $pulses = [];
 
         foreach ($data as $entry)

--- a/tests/PulseBoardTest.php
+++ b/tests/PulseBoardTest.php
@@ -32,7 +32,7 @@ class PulseBoardTest extends PulseUnitTestCase
 
         $this->id = 3844236;
         $this->board = new PulseBoard($this->id);
-        $this->pulses = $this->board->getPulses(1000, 1);
+        $this->pulses = $this->board->getPulses(25, 1);
     }
 
     public function testGetBoardUrl()

--- a/tests/PulseBoardTest.php
+++ b/tests/PulseBoardTest.php
@@ -32,7 +32,7 @@ class PulseBoardTest extends PulseUnitTestCase
 
         $this->id = 3844236;
         $this->board = new PulseBoard($this->id);
-        $this->pulses = $this->board->getPulses();
+        $this->pulses = $this->board->getPulses(1000, 1);
     }
 
     public function testGetBoardUrl()

--- a/tests/PulseColumnGettersTest.php
+++ b/tests/PulseColumnGettersTest.php
@@ -32,7 +32,7 @@ class PulseColumnGettersTest extends PulseUnitTestCase
         $this->userId = self::MainUser; // Main User Account
 
         $this->board = new PulseBoard($this->id);
-        $this->pulses = $this->board->getPulses(1000, 1);
+        $this->pulses = $this->board->getPulses(25, 1);
     }
 
     public function testGetNameColumnValues()

--- a/tests/PulseColumnGettersTest.php
+++ b/tests/PulseColumnGettersTest.php
@@ -32,7 +32,7 @@ class PulseColumnGettersTest extends PulseUnitTestCase
         $this->userId = self::MainUser; // Main User Account
 
         $this->board = new PulseBoard($this->id);
-        $this->pulses = $this->board->getPulses();
+        $this->pulses = $this->board->getPulses(1000, 1);
     }
 
     public function testGetNameColumnValues()


### PR DESCRIPTION
Hello,

This adds parameters to get call for pulses per january API update BUT I believe there are two things to discuss before merging:

1. What the defaults should be? New defaults (per_page 25) or old defaults (per_page 1000)? I've set it to 25 for now, but well, that's for the library author to decide :)

2. There is one usage of this method within library I am not quite sure what to do with (aside setting defaults to 1000 like it was before pagination was introduced): 
https://github.com/allejo/PhpPulse/blob/master/src/Pulse.php#L253
what do you think?