### PR TITLE
Add support for tag columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 0.3.4
+
+- Add support for tagging Pulses ([#18](https://github.com/allejo/PhpPulse/pull/18))
+
 ### 0.3.3
 
 - Add pagination options in `PulseBoard::getPulses()` method ([#17](https://github.com/allejo/PhpPulse/pull/17))

--- a/src/Objects/ApiObject.php
+++ b/src/Objects/ApiObject.php
@@ -290,16 +290,17 @@ abstract class ApiObject implements \JsonSerializable
     /**
      * Convert the specified array into an array of object types if needed
      *
-     * @param  string $objectType The class name of the Objects the items should be
      * @param  array  $array      The array to check
+     * @param  string $objectType The class name of the Objects the items should be
+     * @param  bool   $lazyLoad   Should the casted objects be created lazily
      *
      * @since  0.2.0
      */
-    final protected static function lazyCastAll (&$array, $objectType)
+    final protected static function lazyCastAll (&$array, $objectType, $lazyLoad = false)
     {
         if (self::lazyCastNeededOnArray($objectType, $array))
         {
-            $array = self::castArrayToObjectArray($objectType, $array);
+            $array = self::castArrayToObjectArray($objectType, $array, $lazyLoad);
         }
     }
 
@@ -384,19 +385,20 @@ abstract class ApiObject implements \JsonSerializable
      *
      * @param  string $className The class name of the Object type
      * @param  array  $objects   An associative array to be converted into an object
+     * @param  bool   $lazyLoad  Should the casted objects be created lazily
      *
      * @since  0.2.0
      *
      * @return array An array of the specified objects
      */
-    final protected static function castArrayToObjectArray ($className, $objects)
+    final protected static function castArrayToObjectArray ($className, $objects, $lazyLoad = false)
     {
         $class = self::OBJ_NAMESPACE . $className;
         $array = [];
 
         foreach ($objects as $post)
         {
-            $array[] = new $class($post);
+            $array[] = new $class($post, $lazyLoad);
         }
 
         return $array;

--- a/src/Objects/PulseColumnTagValue.php
+++ b/src/Objects/PulseColumnTagValue.php
@@ -12,6 +12,8 @@ use allejo\DaPulse\PulseTag;
 class PulseColumnTagValue extends PulseColumnValue
 {
     /**
+     * Get the tags in this column.
+     *
      * @return PulseTag[]
      */
     public function getValue ()
@@ -20,11 +22,43 @@ class PulseColumnTagValue extends PulseColumnValue
     }
 
     /**
-     * @param string[] $tags
+     * Override the existing tags in this column with the ones specified in this function call.
+     *
+     * If you'd like to remove just one tag or add a new one, you will have to do first call `getValue()` and manipulate
+     * the array yourself; this is purposely done to prevent an excess of API calls for each minor change.
+     *
+     * @param PulseTag[]|string[] $tags
+     *
+     * @throws \InvalidArgumentException
      */
     public function updateValue (array $tags)
     {
-        throw new \Exception('This method has not been implemented yet');
+        $normalizedTags = [];
+
+        foreach ($tags as $tag)
+        {
+            if (is_string($tag))
+            {
+                $normalizedTags[] = $tag;
+            }
+            elseif ($tag instanceof PulseTag)
+            {
+                $normalizedTags[] = $tag->getName();
+            }
+            else
+            {
+                throw new \InvalidArgumentException('Only strings or PulseTag objects can be set as tags');
+            }
+        }
+
+        $url        = sprintf("%s/%d/columns/%s/tags.json", self::apiEndpoint(), $this->board_id, $this->column_id);
+        $postParams = [
+            "pulse_id" => $this->pulse_id,
+            "tags" => implode(',', $normalizedTags),
+        ];
+
+        $result = self::sendPut($url, $postParams);
+        $this->setValue($result);
     }
 
     /**

--- a/src/Objects/PulseColumnTagValue.php
+++ b/src/Objects/PulseColumnTagValue.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @copyright 2019 Vladimir Jimenez
+ * @license   https://github.com/allejo/PhpPulse/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\DaPulse\Objects;
+
+use allejo\DaPulse\PulseTag;
+
+class PulseColumnTagValue extends PulseColumnValue
+{
+    /**
+     * @return PulseTag[]
+     */
+    public function getValue ()
+    {
+        return parent::getValue();
+    }
+
+    /**
+     * @param string[] $tags
+     */
+    public function updateValue (array $tags)
+    {
+        throw new \Exception('This method has not been implemented yet');
+    }
+
+    /**
+     * Cast and set the appropriate value for this column
+     *
+     * @param $response
+     */
+    protected function setValue ($response)
+    {
+        if (!isset($response['value']['tag_ids'])) {
+            $this->column_value = [];
+
+            return;
+        }
+
+        $this->column_value = $response['value']['tag_ids'];
+
+        self::lazyCastAll($this->column_value, 'PulseTag', true);
+    }
+}

--- a/src/Objects/PulseColumnValue.php
+++ b/src/Objects/PulseColumnValue.php
@@ -108,7 +108,7 @@ abstract class PulseColumnValue extends ApiObject
      *
      * @throws InvalidObjectException
      *
-     * @return PulseColumnStatusValue|PulseColumnDateValue|PulseColumnNumericValue|PulseColumnPersonValue|PulseColumnTextValue|PulseColumnTimelineValue
+     * @return PulseColumnStatusValue|PulseColumnDateValue|PulseColumnNumericValue|PulseColumnPersonValue|PulseColumnTagValue|PulseColumnTextValue|PulseColumnTimelineValue
      */
     public static function _createColumnType ($type, $data)
     {
@@ -132,6 +132,9 @@ abstract class PulseColumnValue extends ApiObject
 
             case PulseColumn::Timeline:
                 return (new PulseColumnTimelineValue($data));
+
+            case PulseColumn::Tag:
+                return (new PulseColumnTagValue($data));
         }
 
         throw new InvalidObjectException("'$type' is an unsupported column type to modify.");

--- a/src/Pulse.php
+++ b/src/Pulse.php
@@ -15,6 +15,7 @@ use allejo\DaPulse\Objects\PulseColumnDateValue;
 use allejo\DaPulse\Objects\PulseColumnNumericValue;
 use allejo\DaPulse\Objects\PulseColumnPersonValue;
 use allejo\DaPulse\Objects\PulseColumnStatusValue;
+use allejo\DaPulse\Objects\PulseColumnTagValue;
 use allejo\DaPulse\Objects\PulseColumnTextValue;
 use allejo\DaPulse\Objects\PulseColumnTimelineValue;
 use allejo\DaPulse\Objects\PulseColumnValue;
@@ -453,6 +454,28 @@ class Pulse extends SubscribableObject
     public function getPersonColumn ($columnId)
     {
         return $this->getColumn($columnId, PulseColumn::Person);
+    }
+
+    /**
+     * Access a tag type column value belonging to this pulse in order to read it or modify.
+     *
+     * This function should only be used to access text type values; an exception will be thrown otherwise.
+     *
+     * @api
+     *
+     * @param  string $columnId The ID of the column to access. This is typically a slugified version of the column name
+     *
+     * @since  0.3.4
+     * @throws ColumnNotFoundException The specified column ID does not exist for this Pulse
+     * @throws InvalidColumnException  The specified column is not a "text" type column
+     * @throws InvalidObjectException  The specified column exists but modification of its value is unsupported either
+     *                                 by this library or the DaPulse API.
+     *
+     * @return PulseColumnTagValue A column object with access to its contents
+     */
+    public function getTagColumn ($columnId)
+    {
+        return $this->getColumn($columnId, PulseColumn::Tag);
     }
 
     /**

--- a/src/PulseColumn.php
+++ b/src/PulseColumn.php
@@ -26,6 +26,7 @@ class PulseColumn extends ApiObject
     const Numeric  = "numeric";
     const Person   = "person";
     const Status   = "status";
+    const Tag      = "tag";
     const Text     = "text";
     const Timeline = "timerange";
 

--- a/src/PulseTag.php
+++ b/src/PulseTag.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * @copyright 2019 Vladimir Jimenez
+ * @license   https://github.com/allejo/PhpPulse/blob/master/LICENSE.md MIT
+ */
+
+namespace allejo\DaPulse;
+
+use allejo\DaPulse\Objects\ApiObject;
+
+class PulseTag extends ApiObject
+{
+    const API_PREFIX = "tags";
+
+    /**
+     * @var string
+     */
+    protected $url;
+
+    /**
+     * @var int
+     */
+    protected $id;
+
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var string
+     */
+    protected $color;
+
+    /**
+     * @var \DateTime
+     */
+    protected $created_at;
+
+    /**
+     * @var \DateTime
+     */
+    protected $updated_at;
+
+    /**
+     * @return string
+     */
+    public function getUrl ()
+    {
+        $this->lazyLoad();
+
+        return $this->url;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId ()
+    {
+        $this->lazyLoad();
+
+        return $this->id;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName ()
+    {
+        $this->lazyLoad();
+
+        return $this->name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getColor ()
+    {
+        $this->lazyLoad();
+
+        return $this->color;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getCreatedAt ()
+    {
+        $this->lazyLoad();
+        self::lazyCast($this->created_at, '\DateTime');
+
+        return $this->created_at;
+    }
+
+    /**
+     * @return \DateTime
+     */
+    public function getUpdatedAt ()
+    {
+        $this->lazyLoad();
+        self::lazyCast($this->updated_at, '\DateTime');
+
+        return $this->updated_at;
+    }
+}

--- a/tests/PulseTagTest.php
+++ b/tests/PulseTagTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace allejo\DaPulse\Tests;
+
+use allejo\DaPulse\PulseTag;
+
+class PulseTagTest extends PulseUnitTest
+{
+    /** @var int */
+    private $id;
+
+    /** @var PulseTag */
+    private $pulseTag;
+
+    public function setUp ()
+    {
+        parent::setUp();
+
+        $this->id = 1081234;
+        $this->pulseTag = new PulseTag($this->id);
+    }
+
+    public function testGetId ()
+    {
+        $this->assertTrue(is_int($this->pulseTag->getId()));
+        $this->assertEquals($this->id, $this->pulseTag->getId());
+    }
+
+    public function testGetName ()
+    {
+        $this->assertEquals('barTag2', $this->pulseTag->getName());
+    }
+
+    public function testGetColor ()
+    {
+        $this->assertEquals('black', $this->pulseTag->getColor());
+    }
+
+    public function testGetCreatedAt ()
+    {
+        $this->assertInstanceOf('\DateTime', $this->pulseTag->getCreatedAt());
+        $this->assertEquals(new \DateTime('2019-01-22T23:21:54Z'), $this->pulseTag->getCreatedAt());
+    }
+
+    public function testGetUpdatedAt ()
+    {
+        $this->assertInstanceOf('\DateTime', $this->pulseTag->getUpdatedAt());
+        $this->assertEquals(new \DateTime('2019-01-20T23:21:54Z'), $this->pulseTag->getUpdatedAt());
+    }
+}

--- a/tests/PulseTest.php
+++ b/tests/PulseTest.php
@@ -3,6 +3,7 @@
 namespace allejo\DaPulse\Tests;
 
 use allejo\DaPulse\Pulse;
+use allejo\DaPulse\PulseTag;
 
 class PulseGettersTest extends PulseUnitTest
 {
@@ -117,5 +118,19 @@ class PulseGettersTest extends PulseUnitTest
 
         $this->assertEquals(1081234, $tag->getId());
         $this->assertEquals('black', $tag->getColor());
+    }
+
+    public function testTagColumnSetValue ()
+    {
+        $column = $this->pulse->getTagColumn('has_tags');
+
+        $existingTag = new PulseTag(1081234);
+        $newTag = 'tagFoo1';
+
+        $column->updateValue([$newTag, $existingTag]);
+
+        $tags = $column->getValue();
+
+        $this->assertCount(2, $tags);
     }
 }

--- a/tests/PulseTest.php
+++ b/tests/PulseTest.php
@@ -100,4 +100,22 @@ class PulseGettersTest extends PulseUnitTest
 
         $this->assertGreaterThan($orig, $pulse->getUpdatedAt());
     }
+
+    public function testGetTagColumn ()
+    {
+        $tagColumn = $this->pulse->getTagColumn('has_tags');
+
+        $tags = $tagColumn->getValue();
+
+        $this->assertPulseObjectType('PulseTag', $tags[0]);
+    }
+
+    public function testGetTagColumnValue ()
+    {
+        $tags = $this->pulse->getTagColumn('has_tags')->getValue();
+        $tag = $tags[0];
+
+        $this->assertEquals(1081234, $tag->getId());
+        $this->assertEquals('black', $tag->getColor());
+    }
 }

--- a/tests/fixtures/PhpPulseVCR-sanitized
+++ b/tests/fixtures/PhpPulseVCR-sanitized
@@ -1616,3 +1616,31 @@
             Content-Length: '2'
             Connection: keep-alive
         body: '{"url":"https://phppulse.monday.com/tags/1081234","id":1081234,"name":"barTag2","color":"black","created_at":"2019-01-22T23:21:54Z","updated_at":"2019-01-20T23:21:54Z"}'
+-
+    request:
+        method: GET
+        url: 'https://api.monday.com/v1/boards/3844236/columns/has_tags/value.json?pulse_id=27157096&api_key=YourApiKeyHere'
+        headers:
+            Host: api.monday.com
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Cache-Control: 'max-age=0, private, must-revalidate'
+            Content-Security-Policy: 'frame-ancestors *.monday.com *.dapulse.dev *.realize.io https://realize.io https://monday.com'
+            Content-Type: application/json
+            Date: 'Sat, 21 Jan 2017 04:30:03 GMT'
+            ETag: '"c162f2d25ac389347b422d15da5601d2"'
+            Server: 'UDI 0.13.36'
+            Status: '200 OK'
+            Strict-Transport-Security: max-age=31536000
+            X-Rack-Cache: miss
+            X-Request-Id: dc568de55a6c470cdb819fa94f2f0365
+            X-Runtime: '0.027021'
+            X-UA-Compatible: 'IE=Edge,chrome=1'
+            X-XSS-Protection: '1; mode=block'
+            Content-Length: '55'
+            Connection: keep-alive
+        body: '{"column_id":"tags","pulse_id":1661234,"value":{"tag_ids":[1081234]}}'

--- a/tests/fixtures/PhpPulseVCR-sanitized
+++ b/tests/fixtures/PhpPulseVCR-sanitized
@@ -1643,4 +1643,33 @@
             X-XSS-Protection: '1; mode=block'
             Content-Length: '55'
             Connection: keep-alive
-        body: '{"column_id":"tags","pulse_id":1661234,"value":{"tag_ids":[1081234]}}'
+        body: '{"column_id":"tags","pulse_id":27157096,"value":{"tag_ids":[1081234]}}'
+-
+    request:
+        method: PUT
+        url: 'https://api.monday.com/v1/boards/3844236/columns/has_tags/tags.json?api_key=YourApiKeyHere'
+        headers:
+            Host: api.monday.com
+        body: 'pulse_id=27157096&tags=tagFoo1%2CbarTag2'
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Cache-Control: 'max-age=0, private, must-revalidate'
+            Content-Security-Policy: 'frame-ancestors *.monday.com *.dapulse.dev *.realize.io https://realize.io https://monday.com'
+            Content-Type: application/json
+            Date: 'Sat, 21 Jan 2017 04:30:07 GMT'
+            ETag: '"ff10b626aeb18f5f172462c7a68f03a4"'
+            Server: 'UDI 0.13.36'
+            Status: '200 OK'
+            Strict-Transport-Security: max-age=31536000
+            X-Rack-Cache: 'invalidate, pass'
+            X-Request-Id: 35c05390eb6dc612771470d177d55cca
+            X-Runtime: '0.043873'
+            X-UA-Compatible: 'IE=Edge,chrome=1'
+            X-XSS-Protection: '1; mode=block'
+            Content-Length: '84'
+            Connection: keep-alive
+        body: '{"column_id":"tags","pulse_id":27157096,"value":{"tag_ids":[1081234,1085678],"added_tag":[{"id":1085678,"name":"tagFoo1","color":"black","tag_links_count":0,"board_id":27168881,"board_name":"Dynamic Board","board_kind":"private"},{"id":1081234,"name":"barTag2","color":"black","tag_links_count":0,"board_id":27168881,"board_name":"Dynamic Board","board_kind":"private"}]}}'

--- a/tests/fixtures/PhpPulseVCR-sanitized
+++ b/tests/fixtures/PhpPulseVCR-sanitized
@@ -1588,3 +1588,31 @@
             Content-Length: '2'
             Connection: keep-alive
         body: '[]'
+-
+    request:
+        method: GET
+        url: 'https://api.monday.com/v1/tags/1081234.json?api_key=YourApiKeyHere'
+        headers:
+            Host: api.monday.com
+    response:
+        status:
+            http_version: '1.1'
+            code: '200'
+            message: OK
+        headers:
+            Cache-Control: 'max-age=0, private, must-revalidate'
+            Content-Security-Policy: 'frame-ancestors *.monday.com *.dapulse.dev *.realize.io https://realize.io https://monday.com'
+            Content-Type: application/json
+            Date: 'Mon, 25 Feb 2018 18:21:36 GMT'
+            ETag: '"d751713988987e9331980363e24189ce"'
+            Server: 'UDI 0.13.36'
+            Status: '200 OK'
+            Strict-Transport-Security: max-age=31536000
+            X-Rack-Cache: 'invalidate, pass'
+            X-Request-Id: 4cff6a515d9d11aa59a16c2fb882730b
+            X-Runtime: '0.095425'
+            X-UA-Compatible: 'IE=Edge,chrome=1'
+            X-XSS-Protection: '1; mode=block'
+            Content-Length: '2'
+            Connection: keep-alive
+        body: '{"url":"https://phppulse.monday.com/tags/1081234","id":1081234,"name":"barTag2","color":"black","created_at":"2019-01-22T23:21:54Z","updated_at":"2019-01-20T23:21:54Z"}'


### PR DESCRIPTION
This PR adds the new `PulseTag` and `PulseColumnTagValue` classes. Here's a basic run down of how to use them.

## Usage

### Setting Tags

```php
use allejo\DaPulse\Pulse;

Pulse::setApiKey('YOUR_API_KEY');

$pulse = new Pulse(-999999, true);
$tagColumn = $pulse->getTagColumn('tags');

// Accepts an array of strings OR PulseTag objects (mixing them is fine)
$tagColumn->updateValue(['foo', 'bar']);
```

Do **not** attempt to create your own `PulseTag` objects unless they already exist in your account. Pass strings along and they will automatically be created if they don't exist. You also do **not** need to create `PulseTag` objects if you want to use an existing tag; just pass along a string and monday.com will handle it for you.

#### Removing All Tags

If you want to remove all the tags from a Pulse, just send the API an empty array.

```php
// ...

$tagColumn->updateValue([]);
```

### Getting Tags

Fetch an array of lazily-loaded PulseTag objects.

```php
$pulse = new Pulse(-999999, true);
$tagColumn = $pulse->getTagColumn('tags');

$tags = $tagColumn->getValue();

foreach ($tags as $tag) {
    echo $tag->getName() . "\n";
}
```

### Adding or Removing *Some* Tags

If you want to add or remove tags from a pulse selectively, you **must** do the array manipulation yourself. There's intentionally no `addTag()` or `removeTag()` methods because this would result in too many API calls for each minor change. Manipulate the array of tags yourself and send the new array back to monday.

```php
$pulse = new Pulse(-999999, true);
$tagColumn = $pulse->getTagColumn('tags');

$tags = $tagColumn->getValue();

$tags[] = 'super-toast';

$tagColumn->updateValue($tags);
```

## Notes

Thanks a lot to @helpwise for providing the JSON responses to API calls I did not have access to.

Closes #15 